### PR TITLE
Code generation

### DIFF
--- a/cmd/cmd/generate.go
+++ b/cmd/cmd/generate.go
@@ -1,0 +1,113 @@
+/*
+Copyright © 2023 Vinyl Linux
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder nor the names of its contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/vinyl-linux/mint/generator"
+	"github.com/vinyl-linux/mint/parser"
+)
+
+// generateCmd represents the generate command
+var generateCmd = &cobra.Command{
+	Use:   "generate ./directory/of/mint-documents",
+	Short: "Generate go code from mint documents",
+	Long: `Generate parses a directory full of mint documents and
+generates valid go code for Marshalling/ Unmarshalling types.
+`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		argCount := len(args)
+
+		if argCount != 1 {
+			return fmt.Errorf("mint document directory missing")
+		}
+
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		a, err := parser.ParseDir(args[0])
+		if err != nil {
+			fmt.Printf("%v\n", err)
+			failer(errInvalid)
+		}
+
+		gen, _ := generator.New(a, &generator.GeneratorOptions{
+			PackageName:             mustString(cmd.Flags().GetString("package")),
+			Directory:               mustString(cmd.Flags().GetString("dest")),
+			MakeDirectory:           mustBool(cmd.Flags().GetBool("mkdir")),
+			CustomFunctionSkeletons: mustBool(cmd.Flags().GetBool("functions")),
+			Clobber:                 mustBool(cmd.Flags().GetBool("clobber")),
+		})
+
+		err = gen.Generate()
+		if err != nil {
+			fmt.Printf("%v\n", err)
+			failer(errInvalid)
+		}
+	},
+}
+
+func mustString(s string, err error) string {
+	if err != nil {
+		panic(err)
+	}
+
+	return s
+}
+
+func mustBool(b bool, err error) bool {
+	if err != nil {
+		panic(err)
+	}
+
+	return b
+}
+
+func init() {
+	rootCmd.AddCommand(generateCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// generateCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	generateCmd.Flags().StringP("package", "p", "types", "Package to generate for")
+	generateCmd.Flags().StringP("dest", "d", "types/", "Directory to generate code into")
+	generateCmd.Flags().BoolP("mkdir", "m", true, "Create dest directory if not exist (note: if the destination directory exists then nothing happens)")
+	generateCmd.Flags().BoolP("functions", "f", false, "Create skeleton functions for any custom validators and/or transforms found in documents")
+	generateCmd.Flags().BoolP("clobber", "c", false, "Clobber any pre-generated validators and/or transforms (note: this replaces all custom code back to placeholders)")
+
+}

--- a/functions.go
+++ b/functions.go
@@ -13,7 +13,7 @@ func DateInPast(name string, t time.Time) error {
 	return nil
 }
 
-func DateInUTC(t time.Time) (time.Time, error) {
+func DateInUtc(t time.Time) (time.Time, error) {
 	return t.UTC(), nil
 }
 

--- a/functions_test.go
+++ b/functions_test.go
@@ -31,7 +31,7 @@ func TestDateInUTC(t *testing.T) {
 		t.Fatalf("expected Local, received %s", s)
 	}
 
-	out, err := DateInUTC(in)
+	out, err := DateInUtc(in)
 	if err != nil {
 		t.Errorf("unexpected error %s", err)
 	}

--- a/generator/functions.go
+++ b/generator/functions.go
@@ -1,0 +1,33 @@
+package generator
+
+import (
+	"fmt"
+
+	"github.com/dave/jennifer/jen"
+	"github.com/iancoleman/strcase"
+)
+
+func toGoFuncName(custom bool, s string) *jen.Statement {
+	csFuncName := toCamel(s)
+
+	switch custom {
+	case false:
+		return jen.Qual(mintPath, csFuncName)
+
+	default:
+		return jen.Id("sf").Dot(csFuncName)
+
+	}
+}
+
+func toCamel(s string) string {
+	return strcase.ToCamel(s)
+}
+
+func marshallerFuncName(s string) string {
+	return fmt.Sprintf("marshall%s", s)
+}
+
+func unmarshallerFuncName(s string) string {
+	return fmt.Sprintf("unmarshall%s", s)
+}

--- a/generator/functions_test.go
+++ b/generator/functions_test.go
@@ -1,0 +1,42 @@
+package generator
+
+import (
+	"testing"
+)
+
+func TestToGoFunc(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		custom   bool
+		function string
+		expect   string
+	}{
+		{"Non-custom function is prefixed with mint, camel cased", false, "do_something", "mint.DoSomething"},
+		{"Custom function is prefixed with sf, camel cased", true, "a_b_c_de", "sf.ABCDe"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			received := toGoFuncName(test.custom, test.function).GoString()
+			if test.expect != received {
+				t.Errorf("expected %q, received %q", test.expect, received)
+			}
+		})
+	}
+}
+
+func TestMarshallerFuncName(t *testing.T) {
+	expect := "marshallField"
+	received := marshallerFuncName("Field")
+
+	if expect != received {
+		t.Errorf("expected %q, received %q", expect, received)
+	}
+}
+
+func TestUnmarshallerFuncName(t *testing.T) {
+	expect := "unmarshallField"
+	received := unmarshallerFuncName("Field")
+
+	if expect != received {
+		t.Errorf("expected %q, received %q", expect, received)
+	}
+}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -1,0 +1,379 @@
+package generator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dave/jennifer/jen"
+	"github.com/vinyl-linux/mint/parser"
+)
+
+const (
+	mintPath = "github.com/vinyl-linux/mint"
+)
+
+var (
+	muvType = jen.Qual(mintPath, "MarshallerUnmarshallerValuer")
+)
+
+type GeneratorOptions struct {
+	PackageName             string
+	MakeDirectory           bool
+	Directory               string
+	CustomFunctionSkeletons bool
+	Clobber                 bool
+}
+
+type Generator struct {
+	GeneratorOptions
+
+	ast             *parser.AST
+	customFunctions []jen.Code
+}
+
+func New(doc *parser.AST, options *GeneratorOptions) (g *Generator, err error) {
+	g = new(Generator)
+	g.GeneratorOptions = *options
+	g.ast = doc
+
+	return
+}
+
+// Generate will create:
+//
+//  1. Type definitions
+//  2. Validations
+//  3. Transforms
+//  4. Unmarshallers; and
+//  5. Marshallers
+//
+// For each type defined in an AST
+func (g *Generator) Generate() (err error) {
+	if g.MakeDirectory {
+		err = os.MkdirAll(g.Directory, 0750)
+		if err != nil {
+			return
+		}
+	}
+
+	for _, t := range g.ast.Types {
+		g.customFunctions = make([]jen.Code, 0)
+
+		ret := jen.NewFile(g.PackageName)
+
+		ret.Add(g.generateType(t))
+		ret.Add(g.generateValidations(t))
+		ret.Add(g.generateTransformations(t))
+		ret.Add(g.generateValuer(t))
+
+		// We need to manually run these loops, rather than exploding
+		// the output of generateUnmarshaller (etc.) as per:
+		//
+		//  ret.Add(g.generateUnmarshaller(t)...)
+		//
+		// because doing so creates invalid code for whatever
+		// reason
+		for _, u := range g.generateUnmarshaller(t) {
+			ret.Add(u)
+		}
+
+		for _, u := range g.generateMarshaller(t) {
+			ret.Add(u)
+		}
+
+		if g.CustomFunctionSkeletons {
+			fn := filepath.Join(g.Directory, strings.Join([]string{strings.ToLower(t.Name), "custom", "go"}, "."))
+			customs := jen.NewFile(g.PackageName)
+			for _, f := range g.customFunctions {
+				customs.Add(f)
+			}
+
+			if _, statErr := os.Stat(fn); statErr != nil || g.Clobber {
+				err = customs.Save(fn)
+				if err != nil {
+					return
+				}
+			}
+		}
+
+		err = ret.Save(filepath.Join(g.Directory, strings.Join([]string{strings.ToLower(t.Name), "go"}, ".")))
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// generateType creates the top level struct from names, types, and
+// doc strings
+func (g *Generator) generateType(at parser.AnnotatedType) (c jen.Code) {
+	fields := make([]jen.Code, 0)
+	for _, f := range at.Entries {
+		if len(f.DocString) > 0 {
+			fields = append(fields, jen.Null().Comment(f.DocString))
+		}
+
+		fields = append(fields, jen.Null().Id(f.Name).Add(toJenType(f.Field)))
+	}
+
+	return jen.Null().Type().Id(at.Name).Struct(
+		fields...,
+	)
+}
+
+// generateValidations creates calls to both mint and custom
+// validations, additionally templating custom validations were
+// requested
+func (g *Generator) generateValidations(at parser.AnnotatedType) (c jen.Code) {
+	functionCalls := make([]jen.Code, 0)
+	for _, e := range at.Entries {
+		for _, f := range e.Validations {
+			fn := toGoFuncName(f.IsCustom, f.Function)
+
+			if g.CustomFunctionSkeletons && f.IsCustom {
+				g.customFunctions = append(g.customFunctions, g.generateSkeletonValidation(at.Name, f.Function))
+			}
+
+			functionCalls = append(functionCalls, fn.Call(jen.Lit(e.Name), jen.Id("sf").Dot(e.Name)))
+		}
+	}
+
+	return jen.Func().Params(jen.Id("sf").Id(at.Name)).
+		Id("Validate").Params().Params(jen.Id("error")).
+		Block(
+			jen.Id("errors").Op(":=").Id("make").Call(jen.Index().Id("error"), jen.Lit(0)),
+			jen.For(jen.List(jen.Id("_"), jen.Id("err")).Op(":=").Range().Index().Id("error").Values(
+				functionCalls...,
+			)).
+				Block(
+					jen.If(
+						jen.Id("err").Op("!=").Id("nil")).Block(
+						jen.Id("errors").Op("=").Id("append").Call(
+							jen.Id("errors"), jen.Id("err")),
+					),
+				),
+			jen.Return().Id("mint").Dot("ValidationErrors").Call(jen.Lit(at.Name), jen.Id("errors")),
+		)
+}
+
+// generateTransformations creates calls to both mint and custom
+// transformations, additionally templating custom transformations were
+// requested
+func (g *Generator) generateTransformations(at parser.AnnotatedType) jen.Code {
+	functionCalls := make([]jen.Code, 0)
+	for _, e := range at.Entries {
+		for _, f := range e.Transformations {
+			fn := toGoFuncName(f.IsCustom, f.Function)
+
+			if g.CustomFunctionSkeletons && f.IsCustom {
+				g.customFunctions = append(g.customFunctions, g.generateSkeletonTransform(at.Name, f.Function))
+			}
+
+			functionCalls = append(functionCalls,
+				jen.List(jen.Id("sf").Dot(e.Name), jen.Id("err")).Op("=").Add(fn).Call(jen.Id("sf").Dot(e.Name)),
+				jen.If(jen.Id("err").Op("!=").Id("nil")).Block(
+					jen.Return(),
+				),
+			)
+		}
+	}
+
+	functionCalls = append(functionCalls, jen.Return())
+
+	return jen.Func().Params(jen.Id("sf").Op("*").Id(at.Name)).Id("Transform").Params().Params(jen.Id("err").Id("error")).
+		Block(
+			functionCalls...,
+		)
+}
+
+// generateUnmarshaller will:
+//  1. Create an unmarshall function per field
+//  2. Create an implementation of the mint.Unmarshaller interface for this type
+func (g *Generator) generateUnmarshaller(at parser.AnnotatedType) (j []jen.Code) {
+	functionCalls := make([]jen.Code, 0)
+	j = make([]jen.Code, 0)
+
+	for _, entry := range at.Entries {
+		switch {
+		case entry.DataType.Scalar != nil:
+			j = append(j, g.unmarshallScalar(at.Name, entry))
+
+		case entry.DataType.Slice != nil,
+			entry.DataType.FixedSizeSlice != nil:
+			j = append(j, g.unmarshallSliceArray(at.Name, entry))
+
+		case entry.DataType.Map != nil:
+			j = append(j, g.unmarshallMap(at.Name, entry))
+
+		default:
+			continue
+		}
+
+		fn := jen.Id("sf").Dot(unmarshallerFuncName(entry.Name))
+		functionCalls = append(functionCalls,
+			jen.If(jen.Id("err").Op("=").Add(fn).Call(jen.Id("r")).Id(";").Id("err").Op("!=").Id("nil")).Block(
+				jen.Return(),
+			),
+		)
+	}
+
+	functionCalls = append(functionCalls,
+		callErrorable("Transform"),
+		callErrorable("Validate"),
+		jen.Return(),
+	)
+
+	j = append(j, jen.Func().Params(jen.Id("sf").Op("*").Id(at.Name)).Id("Unmarshall").Params(jen.Id("r").Qual("io", "Reader")).Params(jen.Id("err").Id("error")).
+		Block(
+			functionCalls...,
+		))
+
+	return
+}
+
+// generateMarshaller will:
+//  1. Create a marshall function per field
+//  2. Create an implementation of the mint.Marshaller interface for this type
+func (g *Generator) generateMarshaller(at parser.AnnotatedType) (j []jen.Code) {
+	functionCalls := []jen.Code{
+		callErrorable("Transform"),
+		callErrorable("Validate"),
+	}
+
+	j = make([]jen.Code, 0)
+
+	for _, e := range at.Entries {
+		fieldName := e.Field.Name
+
+		switch {
+		// if a scalar, and creator isn't 'new' then do
+		// err = mint.$creator(value).Marshall(w) (etc)
+		// else just value.Marshall(w)
+		case e.DataType.Scalar != nil:
+			if _, ok := parser.Scalars[e.DataType.Scalar.Type]; ok {
+				f, _, _ := scalarToMintJen(e.DataType.Scalar.Type)
+				functionCalls = append(functionCalls,
+					jen.If(jen.Id("err").Op("=").Add(f).Call(jen.Id("sf").Dot(fieldName)).Dot("Marshall").Call(jen.Id("w")).Id(";").Id("err").Op("!=").Id("nil")).Block(jen.Return()),
+				)
+
+				continue
+			}
+
+			functionCalls = append(functionCalls,
+				jen.If(jen.Id("err").Op("=").Id("sf").Dot(fieldName).Dot("Marshall").Call(jen.Id("w")).Id(";").Id("err").Op("!=").Id("nil")).Block(jen.Return()),
+			)
+
+		// if a slice or array, then mint.NewSlicecollection, setting
+		// the second arg accordingly)
+		case e.DataType.Slice != nil ||
+			e.DataType.FixedSizeSlice != nil:
+			j = append(j, g.marshallSliceArray(at.Name, e))
+
+			fn := jen.Id("sf").Dot(marshallerFuncName(e.Name))
+			functionCalls = append(functionCalls,
+				jen.If(jen.Id("err").Op("=").Add(fn).Call(jen.Id("w")).Id(";").Id("err").Op("!=").Id("nil")).Block(jen.Return()),
+			)
+
+		// if a map then go from one to the other
+		case e.DataType.Map != nil:
+			j = append(j, g.marshallMap(at.Name, e))
+
+			fn := jen.Id("sf").Dot(marshallerFuncName(e.Name))
+			functionCalls = append(functionCalls,
+				jen.If(jen.Id("err").Op("=").Add(fn).Call(jen.Id("w")).Id(";").Id("err").Op("!=").Id("nil")).Block(jen.Return()),
+			)
+
+		default:
+			continue
+		}
+	}
+
+	functionCalls = append(functionCalls, jen.Return())
+
+	return append(j, jen.Func().Params(jen.Id("sf").Id(at.Name)).Id("Marshall").Params(jen.Id("w").Qual("io", "Writer")).Params(jen.Id("err").Id("error")).
+		Block(
+			functionCalls...,
+		),
+	)
+}
+
+// generateValuer will create an implementation of the mint.Valuer interface
+// for this type.
+//
+// This valuer is, more or less, a no-op; it's there to implement the interface
+// mint.MarshallerUnmarshallerValuer that allows us to work with binary
+// representations of more complex, or exciting types
+func (g *Generator) generateValuer(at parser.AnnotatedType) jen.Code {
+	return jen.Func().Params(jen.Id("sf").Id(at.Name)).Id("Value").Params().Params(jen.Id("any")).
+		Block(
+			jen.Return(jen.Id("sf")),
+		)
+}
+
+func toJenType(t parser.Field) jen.Code {
+	dt := t.DataType
+
+	switch {
+	case dt.Scalar != nil:
+		_, _, goType := scalarToMintJen(t.DataType.Scalar.Type)
+
+		return goType
+
+	case dt.Slice != nil:
+		return jen.Index().Id(dt.Slice.Type)
+
+	case dt.FixedSizeSlice != nil:
+		return jen.Index(jen.Id(fmt.Sprintf("%d", dt.FixedSizeSlice.Size))).Id(dt.FixedSizeSlice.Type)
+
+	case dt.Map != nil:
+		return jen.Map(jen.Id(dt.Map.Key)).Id(dt.Map.Value)
+	}
+
+	return jen.Null()
+}
+
+func callErrorable(f string) jen.Code {
+	return jen.If(jen.Id("err").Op("=").Id("sf").Dot(f).Call().Id(";").Id("err").Op("!=").Id("nil")).Block(jen.Return())
+}
+
+func scalarToMintJen(ts string) (c, nilValue, castType jen.Code) {
+	switch ts {
+	case "string":
+		return jen.Qual(mintPath, "NewStringScalar"), jen.Lit(""), jen.Id(ts)
+
+	case "datetime":
+		return jen.Qual(mintPath, "NewDatetimeScalar"), jen.Qual("time", "Time").Block(), jen.Qual("time", "Time")
+
+	case "uuid":
+		return jen.Qual(mintPath, "NewUuidScalar"), jen.Qual("github.com/gofrs/uuid/v5", "UUID").Block(), jen.Qual("github.com/gofrs/uuid/v5", "UUID")
+
+	case "uint32":
+		return jen.Qual(mintPath, "NewUInt32Scalar"), jen.Id("uint32").Call(jen.Lit(0)), jen.Id(ts)
+
+	case "int16":
+		return jen.Qual(mintPath, "NewInt16Scalar"), jen.Id("int16").Call(jen.Lit(0)), jen.Id(ts)
+
+	case "int32":
+		return jen.Qual(mintPath, "NewInt32Scalar"), jen.Id("int32").Call(jen.Lit(0)), jen.Id(ts)
+
+	case "int64":
+		return jen.Qual(mintPath, "NewInt64Scalar"), jen.Id("int64").Call(jen.Lit(0)), jen.Id(ts)
+
+	case "float32":
+		return jen.Qual(mintPath, "NewFloat32Scalar"), jen.Id("float32").Call(jen.Lit(0)), jen.Id(ts)
+
+	case "float64":
+		return jen.Qual(mintPath, "NewFloat64Scalar"), jen.Id("float64").Call(jen.Lit(0)), jen.Id(ts)
+
+	case "bool":
+		return jen.Qual(mintPath, "NewBoolScalar"), jen.Lit(false), jen.Id(ts)
+
+	case "byte":
+		return jen.Qual(mintPath, "NewByteScalar"), jen.Id("byte").Call(jen.Lit('\x00')), jen.Id(ts)
+	}
+
+	return jen.Id("new"), jen.Id(ts), jen.Id(ts)
+}

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -1,0 +1,257 @@
+package generator
+
+import (
+	"os"
+	"testing"
+
+	"github.com/vinyl-linux/mint/parser"
+	"golang.org/x/mod/sumdb/dirhash"
+)
+
+func TestNew(t *testing.T) {
+	opts := &GeneratorOptions{
+		PackageName: "testtest",
+	}
+
+	g, _ := New(nil, opts)
+
+	if g.PackageName != "testtest" {
+		t.Errorf("expected testtest, received %s", g.PackageName)
+	}
+}
+
+// TestGenerator_Generate is a really silly test, really;
+//
+// We essentially generate a directory full of code and then
+// compare some checksums- this test _wont_ tell you where things
+// have failed; you need other tests to fail to tell you that.
+//
+// This test serves two purposes:
+//
+//  1. Act as a canary for the efficacy of tests (if this fails and
+//     nothing else fails then we have unexpected behaviour)
+//  2. Allows us to provide test coverage for the largest function;
+//     the main generator
+func TestGenerator_Generate(t *testing.T) {
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ast, err := parser.ParseDir("testdata/valid-documents")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts := &GeneratorOptions{
+		PackageName:             "mint_testrun",
+		MakeDirectory:           true,
+		Directory:               dir,
+		CustomFunctionSkeletons: true,
+		Clobber:                 true,
+	}
+
+	g, _ := New(ast, opts)
+	err = g.Generate()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := "h1:H/ivkG97ylTC8lCmAZbtmzstj+/foFqaNEKOiLRIdcQ="
+	received, err := dirhash.HashDir(dir, "", dirhash.DefaultHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if expect != received {
+		t.Fatalf("expected %q, received %q", expect, received)
+	}
+}
+
+func TestGenerator_generateType(t *testing.T) {
+	g := new(Generator)
+
+	expect := `type SomeTestType struct {
+	SomeStringSlice []string
+	SomeStringSlice [5]string
+	// An int64 for some reason
+	SomeStringSlice map[string]int64
+	// ATypeOfSomeType is a uuid
+	ATypeOfSomeType v5.UUID
+	Thingy          BlahType
+}`
+	received := codeToString(g.generateType(simpleType))
+
+	if expect != received {
+		t.Errorf("expected\n%s\nreceived\n%s", expect, received)
+	}
+
+}
+
+func TestGenerator_generateValidations(t *testing.T) {
+	g := new(Generator)
+	g.GeneratorOptions.CustomFunctionSkeletons = true
+
+	expectFuncs := `package test
+
+func (sf SomeTestType) BlahBlahBlahHowDoesThisEvaluate(string, any) error {
+	return nil
+}
+`
+
+	expect := `func (sf SomeTestType) Validate() error {
+	errors := make([]error, 0)
+	for _, err := range []error{mint.NotEmpty("ATypeOfSomeType", sf.ATypeOfSomeType), sf.BlahBlahBlahHowDoesThisEvaluate("ATypeOfSomeType", sf.ATypeOfSomeType)} {
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+	return mint.ValidationErrors("SomeTestType", errors)
+}`
+	t.Run("Validate()", func(t *testing.T) {
+		received := codeToString(g.generateValidations(simpleType))
+
+		if expect != received {
+			t.Errorf("expected\n%s\nreceived\n%s", expect, received)
+		}
+	})
+
+	t.Run("Skeleton function(s)", func(t *testing.T) {
+		received := codeSliceToFile(g.customFunctions)
+
+		if expectFuncs != received {
+			t.Errorf("expected\n%s\nreceived\n%s", expectFuncs, received)
+		}
+
+	})
+}
+
+func TestGenerator_generateTransformations(t *testing.T) {
+	g := new(Generator)
+	g.GeneratorOptions.CustomFunctionSkeletons = true
+
+	expectFuncs := `package test
+
+func Floop(any) (any, error) {
+	return nil, nil
+}
+func TrebleValue(any) (any, error) {
+	return nil, nil
+}
+`
+
+	expect := `func (sf *SomeTestType) Transform() (err error) {
+	sf.SomeStringSlice, err = sf.Floop(sf.SomeStringSlice)
+	if err != nil {
+		return
+	}
+	sf.SomeStringSlice, err = sf.TrebleValue(sf.SomeStringSlice)
+	if err != nil {
+		return
+	}
+	sf.SomeStringSlice, err = mint.Flipbits(sf.SomeStringSlice)
+	if err != nil {
+		return
+	}
+	return
+}`
+	t.Run("Validate()", func(t *testing.T) {
+		received := codeToString(g.generateTransformations(simpleType))
+
+		if expect != received {
+			t.Errorf("expected\n%s\nreceived\n%s", expect, received)
+		}
+	})
+
+	t.Run("Skeleton function(s)", func(t *testing.T) {
+		received := codeSliceToFile(g.customFunctions)
+
+		if expectFuncs != received {
+			t.Errorf("expected\n%s\nreceived\n%s", expectFuncs, received)
+		}
+
+	})
+}
+
+func TestGenerator_generateUnmarshaller(t *testing.T) {
+	g := new(Generator)
+
+	expect := simpleTypeStringUnmarshaller
+	received := codeSliceToFile(g.generateUnmarshaller(simpleType))
+
+	if expect != received {
+		t.Errorf("expected\n%s\nreceived\n%s", expect, received)
+	}
+}
+
+func TestGenerator_generateMarshaller(t *testing.T) {
+	g := new(Generator)
+
+	expect := simpleTypeStringMarshaller
+	received := codeSliceToFile(g.generateMarshaller(simpleType))
+
+	if expect != received {
+		t.Errorf("expected\n%s\nreceived\n%s", expect, received)
+	}
+}
+
+func TestGenerator_generateValuer(t *testing.T) {
+	g := new(Generator)
+
+	expect := `func (sf SomeTestType) Value() any {
+	return sf
+}`
+	received := codeToString(g.generateValuer(simpleType))
+
+	if expect != received {
+		t.Errorf("expected\n%s\nreceived\n%s", expect, received)
+	}
+}
+
+func TestScalarToMintJen(t *testing.T) {
+	for _, test := range []struct {
+		ts                string
+		expectInitialiser string
+		expectNilValue    string
+		expectCastType    string
+	}{
+		{"string", "mint.NewStringScalar", `""`, "string"},
+		{"datetime", "mint.NewDatetimeScalar", "time.Time{}", "time.Time"},
+		{"uuid", "mint.NewUuidScalar", "v5.UUID{}", "v5.UUID"},
+		{"uint32", "mint.NewUInt32Scalar", "uint32(0)", "uint32"},
+		{"int16", "mint.NewInt16Scalar", "int16(0)", "int16"},
+		{"int32", "mint.NewInt32Scalar", "int32(0)", "int32"},
+		{"int64", "mint.NewInt64Scalar", "int64(0)", "int64"},
+		{"float32", "mint.NewFloat32Scalar", "float32(0)", "float32"},
+		{"float64", "mint.NewFloat64Scalar", "float64(0)", "float64"},
+		{"bool", "mint.NewBoolScalar", "false", "bool"},
+		{"byte", "mint.NewByteScalar", "byte(int32(0))", "byte"},
+		{"SomeType", "new", "SomeType", "SomeType"},
+	} {
+		t.Run(test.ts, func(t *testing.T) {
+			receivedInitialiser, receivedNilValue, receivedCastType := scalarToMintJen(test.ts)
+
+			t.Run("initialiser", func(t *testing.T) {
+				s := codeToString(receivedInitialiser)
+				if test.expectInitialiser != s {
+					t.Errorf("expected %s, reveived %s", test.expectInitialiser, s)
+				}
+			})
+
+			t.Run("nilvalue", func(t *testing.T) {
+				s := codeToString(receivedNilValue)
+				if test.expectNilValue != s {
+					t.Errorf("expected %s, reveived %s", test.expectNilValue, s)
+				}
+			})
+
+			t.Run("castType", func(t *testing.T) {
+				s := codeToString(receivedCastType)
+				if test.expectCastType != s {
+					t.Errorf("expected %s, reveived %s", test.expectCastType, s)
+				}
+			})
+
+		})
+	}
+}

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -80,7 +80,7 @@ func TestGenerator_generateType(t *testing.T) {
 	ATypeOfSomeType v5.UUID
 	Thingy          BlahType
 }`
-	received := codeToString(g.generateType(simpleType))
+	received := codeToString(g.generateTypeDefinition(simpleType))
 
 	if expect != received {
 		t.Errorf("expected\n%s\nreceived\n%s", expect, received)

--- a/generator/marshallers.go
+++ b/generator/marshallers.go
@@ -1,0 +1,57 @@
+package generator
+
+import (
+	"github.com/dave/jennifer/jen"
+	"github.com/vinyl-linux/mint/parser"
+)
+
+func (g Generator) marshallSliceArray(t string, e parser.AnnotatedEntry) jen.Code {
+	var (
+		dt string
+	)
+
+	if e.Field.DataType == nil {
+		return jen.Null()
+	}
+
+	switch {
+	case e.Field.DataType.Slice != nil:
+		dt = e.Field.DataType.Slice.Type
+
+	case e.Field.DataType.FixedSizeSlice != nil:
+		dt = e.Field.DataType.FixedSizeSlice.Type
+
+	default:
+		return jen.Null()
+	}
+
+	fn := marshallerFuncName(e.Name)
+	innerInitialiser, _, _ := scalarToMintJen(dt)
+
+	return jen.Func().Params(jen.Id("sf").Id(t)).Id(fn).Params(jen.Id("w").Qual("io", "Writer")).Params(jen.Id("err").Id("error")).
+		Block(
+			jen.Id("f").Op(":=").Id("make").Call(jen.Index().Add(muvType), jen.Id("len").Call(jen.Id("sf").Dot(e.Field.Name))),
+			jen.For(jen.Id("i").Op(":=").Id("range").Id("f")).Block(
+				jen.Id("f").Index(jen.Id("i")).Op("=").Add(innerInitialiser).Call(jen.Id("sf").Dot(e.Field.Name).Index(jen.Id("i"))),
+			),
+			jen.Return(jen.Qual(mintPath, "NewSliceCollection").Call(jen.Id("f"), jen.Lit(e.Field.DataType.FixedSizeSlice != nil)).Dot("Marshall").Call(jen.Id("w"))),
+		)
+
+}
+
+func (g Generator) marshallMap(t string, e parser.AnnotatedEntry) jen.Code {
+	fn := marshallerFuncName(e.Name)
+
+	keyInitialiser, _, _ := scalarToMintJen(e.DataType.Map.Key)
+	valueInitialiser, _, _ := scalarToMintJen(e.DataType.Map.Value)
+
+	return jen.Func().Params(jen.Id("sf").Id(t)).Id(fn).Params(jen.Id("w").Qual("io", "Writer")).Params(jen.Id("err").Id("error")).
+		Block(
+			jen.Id("f").Op(":=").Id("make").Call(jen.Id("map").Index(jen.Add(muvType)).Add(muvType)),
+			jen.For(jen.Id("k").Op(",").Id("v").Op(":=").Id("range").Id("sf").Dot(e.Name)).Block(
+				jen.Id("f").Index(jen.Add(keyInitialiser).Call(jen.Id("k"))).Op("=").Add(valueInitialiser).Call(jen.Id("v")),
+			),
+			jen.Return(jen.Qual(mintPath, "NewMapCollection").Call(jen.Id("f")).Dot("Marshall").Call(jen.Id("w"))),
+		)
+
+}

--- a/generator/marshallers_test.go
+++ b/generator/marshallers_test.go
@@ -1,0 +1,59 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/vinyl-linux/mint/parser"
+)
+
+func TestGenerator_marshallSliceArray(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		ae     parser.AnnotatedEntry
+		expect string
+	}{
+		{"Non-fixed length slice writes length", nonFixedLengthSlice, `func (sf TestType) marshallSomeStringSlice(w io.Writer) (err error) {
+	f := make([]mint.MarshallerUnmarshallerValuer, len(sf.SomeStringSlice))
+	for i := range f {
+		f[i] = mint.NewStringScalar(sf.SomeStringSlice[i])
+	}
+	return mint.NewSliceCollection(f, false).Marshall(w)
+}`},
+		{"Fixed length slice writes length", fixedLengthSlice, `func (sf TestType) marshallSomeStringSlice(w io.Writer) (err error) {
+	f := make([]mint.MarshallerUnmarshallerValuer, len(sf.SomeStringSlice))
+	for i := range f {
+		f[i] = mint.NewStringScalar(sf.SomeStringSlice[i])
+	}
+	return mint.NewSliceCollection(f, true).Marshall(w)
+}`},
+		{"Bad input does nothing", parser.AnnotatedEntry{}, ""},
+		{"Non-slice returns nothing", parser.AnnotatedEntry{Field: parser.Field{DataType: &parser.DataType{}}}, ""},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			g := new(Generator)
+			received := codeToString(g.marshallSliceArray("TestType", test.ae))
+
+			if test.expect != received {
+				t.Errorf("expected\n%s\nreceived\n%s", test.expect, received)
+			}
+		})
+	}
+}
+
+func TestGenerator_marshallMap(t *testing.T) {
+	g := new(Generator)
+
+	expect := `func (sf TestType) marshallSomeStringSlice(w io.Writer) (err error) {
+	f := make(map[mint.MarshallerUnmarshallerValuer]mint.MarshallerUnmarshallerValuer)
+	for k, v := range sf.SomeStringSlice {
+		f[mint.NewStringScalar(k)] = mint.NewInt64Scalar(v)
+	}
+	return mint.NewMapCollection(f).Marshall(w)
+}`
+	received := codeToString(g.marshallMap("TestType", mapEntry))
+
+	if expect != received {
+		t.Errorf("expected\n%s\nreceived\n%s", expect, received)
+	}
+
+}

--- a/generator/skeletons.go
+++ b/generator/skeletons.go
@@ -1,0 +1,17 @@
+package generator
+
+import (
+	"github.com/dave/jennifer/jen"
+)
+
+func (g *Generator) generateSkeletonValidation(t string, fn string) jen.Code {
+	return jen.Func().Params(jen.Id("sf").Id(t)).Id(toCamel(fn)).Params(jen.Id("string"), jen.Id("any")).Params(jen.Id("error")).Block(
+		jen.Return(jen.Id("nil")),
+	)
+}
+
+func (g *Generator) generateSkeletonTransform(t string, fn string) jen.Code {
+	return jen.Func().Id(toCamel(fn)).Params(jen.Id("any")).Params(jen.Id("any"), jen.Id("error")).Block(
+		jen.Return(jen.Id("nil"), jen.Id("nil")),
+	)
+}

--- a/generator/skeletons_test.go
+++ b/generator/skeletons_test.go
@@ -1,0 +1,31 @@
+package generator
+
+import (
+	"testing"
+)
+
+func TestGenerator_generateSkeletonValidation(t *testing.T) {
+	expect := `func (sf TestType) ValidateSomeField(string, any) error {
+	return nil
+}`
+
+	g := new(Generator)
+	received := codeToString(g.generateSkeletonValidation("TestType", "validate_some_field"))
+
+	if expect != received {
+		t.Errorf("expected\n%s\nreceived\n%s", expect, received)
+	}
+}
+
+func TestGenerator_generateSkeletonTransform(t *testing.T) {
+	expect := `func ChangeAThing(any) (any, error) {
+	return nil, nil
+}`
+
+	g := new(Generator)
+	received := codeToString(g.generateSkeletonTransform("TestType", "change_a_thing"))
+
+	if expect != received {
+		t.Errorf("expected\n%s\nreceived\n%s", expect, received)
+	}
+}

--- a/generator/testdata
+++ b/generator/testdata
@@ -1,0 +1,1 @@
+../testdata/

--- a/generator/types_test.go
+++ b/generator/types_test.go
@@ -1,0 +1,274 @@
+package generator
+
+import (
+	"github.com/dave/jennifer/jen"
+	"github.com/vinyl-linux/mint/parser"
+)
+
+var (
+	nonFixedLengthSlice = parser.AnnotatedEntry{
+		Field: parser.Field{
+			Name: "SomeStringSlice",
+			DataType: &parser.DataType{
+				Slice: &parser.SliceType{
+					Type: "string",
+				},
+			},
+		},
+	}
+
+	fixedLengthSlice = parser.AnnotatedEntry{
+		Transformations: []parser.Transformation{
+			{
+				IsCustom: true,
+				Function: "floop",
+			},
+		},
+		Field: parser.Field{
+			Name: "SomeStringSlice",
+			DataType: &parser.DataType{
+				FixedSizeSlice: &parser.FixedSizedSliceType{
+					Type: "string",
+					Size: 5,
+				},
+			},
+		},
+	}
+
+	mapEntry = parser.AnnotatedEntry{
+		DocString: "An int64 for some reason",
+		Transformations: []parser.Transformation{
+			{
+				IsCustom: true,
+				Function: "treble_value",
+			},
+			{
+				IsCustom: false,
+				Function: "flipbits",
+			},
+		},
+		Field: parser.Field{
+			Name: "SomeStringSlice",
+			DataType: &parser.DataType{
+				Map: &parser.MapType{
+					Key:   "string",
+					Value: "int64",
+				},
+			},
+		},
+	}
+
+	scalarEntry = parser.AnnotatedEntry{
+		DocString: "ATypeOfSomeType is a uuid",
+		Validations: []parser.Validation{
+			{
+				IsCustom: false,
+				Function: "not_empty",
+			},
+			{
+				IsCustom: true,
+				Function: "blah_blah_blah-how-does-this.evaluate",
+			},
+		},
+		Field: parser.Field{
+			Name: "ATypeOfSomeType",
+			DataType: &parser.DataType{
+				Scalar: &parser.Scalar{
+					Type: "uuid",
+				},
+			},
+		},
+	}
+
+	userDefinedScalarEntry = parser.AnnotatedEntry{
+		Field: parser.Field{
+			Name: "Thingy",
+			DataType: &parser.DataType{
+				Scalar: &parser.Scalar{
+					Type: "BlahType",
+				},
+			},
+		},
+	}
+
+	simpleType = parser.AnnotatedType{
+		Name: "SomeTestType",
+		Entries: []parser.AnnotatedEntry{
+			nonFixedLengthSlice,
+			fixedLengthSlice,
+			mapEntry,
+			scalarEntry,
+			userDefinedScalarEntry,
+		},
+	}
+
+	simpleTypeStringUnmarshaller = `package test
+
+import (
+	v5 "github.com/gofrs/uuid/v5"
+	mint "github.com/vinyl-linux/mint"
+	"io"
+)
+
+func (sf *SomeTestType) unmarshallSomeStringSlice(r io.Reader) (err error) {
+	f := mint.NewSliceCollection(nil, false)
+	f.ReadSize(r)
+	f.V = make([]mint.MarshallerUnmarshallerValuer, f.Len())
+	for i := range f.V {
+		f.V[i] = mint.NewStringScalar("")
+	}
+	err = f.Unmarshall(r)
+	if err != nil {
+		return
+	}
+	sf.SomeStringSlice = make([]string, f.Len())
+	for i, v := range f.Value().([]mint.MarshallerUnmarshallerValuer) {
+		sf.SomeStringSlice[i] = v.Value().(string)
+	}
+	return
+}
+func (sf *SomeTestType) unmarshallSomeStringSlice(r io.Reader) (err error) {
+	f := mint.NewSliceCollection(make([]mint.MarshallerUnmarshallerValuer, 5), true)
+	for i := range f.V {
+		f.V[i] = mint.NewStringScalar("")
+	}
+	err = f.Unmarshall(r)
+	if err != nil {
+		return
+	}
+	sf.SomeStringSlice = [5]string{}
+	for i, v := range f.Value().([]mint.MarshallerUnmarshallerValuer) {
+		sf.SomeStringSlice[i] = v.Value().(string)
+	}
+	return
+}
+func (sf *SomeTestType) unmarshallSomeStringSlice(r io.Reader) (err error) {
+	f := mint.NewMapCollection(map[mint.MarshallerUnmarshallerValuer]mint.MarshallerUnmarshallerValuer{})
+	f.ReadSize(r)
+	for i := 0; i < f.Len(); i++ {
+		f.V[mint.NewStringScalar("")] = mint.NewInt64Scalar(int64(0))
+	}
+	err = f.Unmarshall(r)
+	if err != nil {
+		return
+	}
+	sf.SomeStringSlice = make(map[string]int64)
+	for k, v := range f.Value().(map[mint.MarshallerUnmarshallerValuer]mint.MarshallerUnmarshallerValuer) {
+		sf.SomeStringSlice[k.Value().(string)] = v.Value().(int64)
+	}
+	return
+}
+func (sf *SomeTestType) unmarshallATypeOfSomeType(r io.Reader) (err error) {
+	f := mint.NewUuidScalar(v5.UUID{})
+	err = f.Unmarshall(r)
+	if err != nil {
+		return
+	}
+	sf.ATypeOfSomeType = f.Value().(v5.UUID)
+	return
+}
+func (sf *SomeTestType) unmarshallThingy(r io.Reader) (err error) {
+	f := new(BlahType)
+	err = f.Unmarshall(r)
+	if err != nil {
+		return
+	}
+	sf.Thingy = f.Value().(BlahType)
+	return
+}
+func (sf *SomeTestType) Unmarshall(r io.Reader) (err error) {
+	if err = sf.unmarshallSomeStringSlice(r); err != nil {
+		return
+	}
+	if err = sf.unmarshallSomeStringSlice(r); err != nil {
+		return
+	}
+	if err = sf.unmarshallSomeStringSlice(r); err != nil {
+		return
+	}
+	if err = sf.unmarshallATypeOfSomeType(r); err != nil {
+		return
+	}
+	if err = sf.unmarshallThingy(r); err != nil {
+		return
+	}
+	if err = sf.Transform(); err != nil {
+		return
+	}
+	if err = sf.Validate(); err != nil {
+		return
+	}
+	return
+}
+`
+
+	simpleTypeStringMarshaller = `package test
+
+import (
+	mint "github.com/vinyl-linux/mint"
+	"io"
+)
+
+func (sf SomeTestType) marshallSomeStringSlice(w io.Writer) (err error) {
+	f := make([]mint.MarshallerUnmarshallerValuer, len(sf.SomeStringSlice))
+	for i := range f {
+		f[i] = mint.NewStringScalar(sf.SomeStringSlice[i])
+	}
+	return mint.NewSliceCollection(f, false).Marshall(w)
+}
+func (sf SomeTestType) marshallSomeStringSlice(w io.Writer) (err error) {
+	f := make([]mint.MarshallerUnmarshallerValuer, len(sf.SomeStringSlice))
+	for i := range f {
+		f[i] = mint.NewStringScalar(sf.SomeStringSlice[i])
+	}
+	return mint.NewSliceCollection(f, true).Marshall(w)
+}
+func (sf SomeTestType) marshallSomeStringSlice(w io.Writer) (err error) {
+	f := make(map[mint.MarshallerUnmarshallerValuer]mint.MarshallerUnmarshallerValuer)
+	for k, v := range sf.SomeStringSlice {
+		f[mint.NewStringScalar(k)] = mint.NewInt64Scalar(v)
+	}
+	return mint.NewMapCollection(f).Marshall(w)
+}
+func (sf SomeTestType) Marshall(w io.Writer) (err error) {
+	if err = sf.Transform(); err != nil {
+		return
+	}
+	if err = sf.Validate(); err != nil {
+		return
+	}
+	if err = sf.marshallSomeStringSlice(w); err != nil {
+		return
+	}
+	if err = sf.marshallSomeStringSlice(w); err != nil {
+		return
+	}
+	if err = sf.marshallSomeStringSlice(w); err != nil {
+		return
+	}
+	if err = mint.NewUuidScalar(sf.ATypeOfSomeType).Marshall(w); err != nil {
+		return
+	}
+	if err = sf.Thingy.Marshall(w); err != nil {
+		return
+	}
+	return
+}
+`
+)
+
+func codeToString(c jen.Code) string {
+	s := make(jen.Statement, 1)
+	s[0] = c
+
+	return s.GoString()
+}
+
+func codeSliceToFile(c []jen.Code) string {
+	f := jen.NewFile("test")
+	for _, stmnt := range c {
+		f.Add(stmnt)
+	}
+
+	return f.GoString()
+}

--- a/generator/unmarshallers.go
+++ b/generator/unmarshallers.go
@@ -1,0 +1,116 @@
+package generator
+
+import (
+	"github.com/dave/jennifer/jen"
+	"github.com/vinyl-linux/mint/parser"
+)
+
+func (g Generator) unmarshallSliceArray(t string, e parser.AnnotatedEntry) jen.Code {
+	fn := unmarshallerFuncName(e.Name)
+	var (
+		block []jen.Code
+		maker jen.Code
+		dt    string
+	)
+
+	if e.Field.DataType == nil {
+		return jen.Null()
+	}
+
+	switch {
+	case e.Field.DataType.Slice != nil:
+		block = unmarshallSlicePreludeGetLen(e)
+		dt = e.Field.DataType.Slice.Type
+		maker = jen.Id("sf").Dot(e.Field.Name).Op("=").Id("make").Call(jen.Index().Id(dt), jen.Id("f").Dot("Len").Call())
+
+	case e.Field.DataType.FixedSizeSlice != nil:
+		block = unmarshallSlicePreludeFixedLen(e)
+		dt = e.Field.DataType.FixedSizeSlice.Type
+		maker = jen.Id("sf").Dot(e.Field.Name).Op("=").Index(jen.Lit(e.Field.DataType.FixedSizeSlice.Size)).Id(dt).Block()
+
+	default:
+		return jen.Null()
+	}
+
+	innerInitialiser, innerNilValue, innerCastType := scalarToMintJen(dt)
+
+	for _, stmt := range []jen.Code{
+		jen.For(jen.List(jen.Id("i"), jen.Null()).Op(":=").Range().Id("f").Dot("V")).Block(
+			jen.Id("f").Dot("V").Index(jen.Id("i")).Op("=").Add(innerInitialiser).Call(innerNilValue),
+		),
+		jen.Id("err").Op("=").Id("f").Dot("Unmarshall").Call(jen.Id("r")),
+		jen.If(jen.Id("err").Op("!=").Id("nil")).Block(
+			jen.Return(),
+		),
+		maker,
+		jen.For(
+			jen.List(jen.Id("i"), jen.Id("v")).Op(":=").Range().Id("f").Dot("Value").Call().Assert(jen.Index().Qual(mintPath, "MarshallerUnmarshallerValuer"))).Block(
+			jen.Id("sf").Dot(e.Field.Name).Index(jen.Id("i")).Op("=").Id("v").Dot("Value").Call().Assert(innerCastType),
+		),
+		jen.Return(),
+	} {
+		block = append(block, stmt)
+	}
+
+	return jen.Func().Params(jen.Id("sf").Op("*").Id(t)).Id(fn).Params(jen.Id("r").Qual("io", "Reader")).Params(jen.Id("err").Id("error")).
+		Block(
+			block...,
+		)
+}
+
+func (g Generator) unmarshallMap(t string, e parser.AnnotatedEntry) jen.Code {
+	fn := unmarshallerFuncName(e.Name)
+
+	keyInitialiser, keyNilValue, keyCastType := scalarToMintJen(e.DataType.Map.Key)
+	valueInitialiser, valueNilValue, valueCastType := scalarToMintJen(e.DataType.Map.Value)
+
+	return jen.Func().Params(jen.Id("sf").Op("*").Id(t)).Id(fn).Params(jen.Id("r").Qual("io", "Reader")).Params(jen.Id("err").Id("error")).
+		Block(
+			jen.Id("f").Op(":=").Qual(mintPath, "NewMapCollection").Call(jen.Id("map").Index(muvType).Add(muvType).Block()),
+			jen.Id("f").Dot("ReadSize").Call(jen.Id("r")),
+
+			jen.For(jen.Id("i").Op(":=").Lit(0), jen.Id("i").Op("<").Id("f").Dot("Len").Call(), jen.Id("i").Op("++")).Block(
+				jen.Id("f").Dot("V").Index(jen.Add(keyInitialiser).Call(keyNilValue)).Op("=").Add(valueInitialiser).Call(valueNilValue),
+			),
+
+			jen.Id("err").Op("=").Id("f").Dot("Unmarshall").Call(jen.Id("r")),
+			jen.If(jen.Id("err").Op("!=").Id("nil")).Block(
+				jen.Return(),
+			),
+
+			jen.Id("sf").Dot(e.Name).Op("=").Id("make").Call(jen.Map(keyCastType).Add(valueCastType)),
+
+			jen.For(jen.List(jen.Id("k"), jen.Id("v")).Op(":=").Range().Id("f").Dot("Value").Call().Assert(jen.Map(muvType).Add(muvType))).Block(
+				jen.Id("sf").Dot(e.Name).Index(jen.Id("k").Dot("Value").Call().Assert(keyCastType)).Op("=").Id("v").Dot("Value").Call().Assert(valueCastType),
+			),
+			jen.Return(),
+		)
+
+}
+
+func (g Generator) unmarshallScalar(t string, e parser.AnnotatedEntry) jen.Code {
+	fn := unmarshallerFuncName(e.Name)
+	initialiser, nilValue, castType := scalarToMintJen(e.Field.DataType.Scalar.Type)
+
+	return jen.Func().Params(jen.Id("sf").Op("*").Id(t)).Id(fn).Params(jen.Id("r").Qual("io", "Reader")).Params(jen.Id("err").Id("error")).
+		Block(
+			jen.Id("f").Op(":=").Add(initialiser).Call(nilValue), jen.Id("err").Op("=").Id("f").Dot("Unmarshall").Call(jen.Id("r")),
+			jen.If(jen.Id("err").Op("!=").Id("nil")).Block(
+				jen.Return(),
+			),
+			jen.Id("sf").Dot(e.Name).Op("=").Id("f").Dot("Value").Call().Assert(castType),
+			jen.Return(),
+		)
+}
+
+func unmarshallSlicePreludeGetLen(e parser.AnnotatedEntry) []jen.Code {
+	return []jen.Code{
+		jen.Id("f").Op(":=").Id("mint").Dot("NewSliceCollection").Call(jen.Id("nil"), jen.Id("false")),
+		jen.Id("f").Dot("ReadSize").Call(jen.Id("r")),
+		jen.Id("f").Dot("V").Op("=").Id("make").Call(jen.Index().Qual(mintPath, "MarshallerUnmarshallerValuer"), jen.Id("f").Dot("Len").Call()),
+	}
+}
+
+func unmarshallSlicePreludeFixedLen(e parser.AnnotatedEntry) []jen.Code {
+	return []jen.Code{jen.Id("f").Op(":=").Qual(mintPath, "NewSliceCollection").Call(jen.Id("make").Call(jen.Index().Add(muvType), jen.Lit(e.DataType.FixedSizeSlice.Size)), jen.Id("true"))}
+}

--- a/generator/unmarshallers.go
+++ b/generator/unmarshallers.go
@@ -34,7 +34,7 @@ func (g Generator) unmarshallSliceArray(t string, e parser.AnnotatedEntry) jen.C
 
 	innerInitialiser, innerNilValue, innerCastType := scalarToMintJen(dt)
 
-	for _, stmt := range []jen.Code{
+	block = append(block, []jen.Code{
 		jen.For(jen.List(jen.Id("i"), jen.Null()).Op(":=").Range().Id("f").Dot("V")).Block(
 			jen.Id("f").Dot("V").Index(jen.Id("i")).Op("=").Add(innerInitialiser).Call(innerNilValue),
 		),
@@ -48,9 +48,7 @@ func (g Generator) unmarshallSliceArray(t string, e parser.AnnotatedEntry) jen.C
 			jen.Id("sf").Dot(e.Field.Name).Index(jen.Id("i")).Op("=").Id("v").Dot("Value").Call().Assert(innerCastType),
 		),
 		jen.Return(),
-	} {
-		block = append(block, stmt)
-	}
+	}...)
 
 	return jen.Func().Params(jen.Id("sf").Op("*").Id(t)).Id(fn).Params(jen.Id("r").Qual("io", "Reader")).Params(jen.Id("err").Id("error")).
 		Block(

--- a/generator/unmarshallers_test.go
+++ b/generator/unmarshallers_test.go
@@ -1,0 +1,112 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/vinyl-linux/mint/parser"
+)
+
+var (
+	nonFixedLengthUnmarshaller = `func (sf *TestType) unmarshallSomeStringSlice(r io.Reader) (err error) {
+	f := mint.NewSliceCollection(nil, false)
+	f.ReadSize(r)
+	f.V = make([]mint.MarshallerUnmarshallerValuer, f.Len())
+	for i := range f.V {
+		f.V[i] = mint.NewStringScalar("")
+	}
+	err = f.Unmarshall(r)
+	if err != nil {
+		return
+	}
+	sf.SomeStringSlice = make([]string, f.Len())
+	for i, v := range f.Value().([]mint.MarshallerUnmarshallerValuer) {
+		sf.SomeStringSlice[i] = v.Value().(string)
+	}
+	return
+}`
+
+	fixedLengthUnmarshaller = `func (sf *TestType) unmarshallSomeStringSlice(r io.Reader) (err error) {
+	f := mint.NewSliceCollection(make([]mint.MarshallerUnmarshallerValuer, 5), true)
+	for i := range f.V {
+		f.V[i] = mint.NewStringScalar("")
+	}
+	err = f.Unmarshall(r)
+	if err != nil {
+		return
+	}
+	sf.SomeStringSlice = [5]string{}
+	for i, v := range f.Value().([]mint.MarshallerUnmarshallerValuer) {
+		sf.SomeStringSlice[i] = v.Value().(string)
+	}
+	return
+}`
+)
+
+func TestGenerator_unmarshallSliceArray(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		ae     parser.AnnotatedEntry
+		expect string
+	}{
+		{"Non-fixed length slice writes length", nonFixedLengthSlice, nonFixedLengthUnmarshaller},
+		{"Fixed length slice writes length", fixedLengthSlice, fixedLengthUnmarshaller},
+		{"Bad input does nothing", parser.AnnotatedEntry{}, ""},
+		{"Non-slice returns nothing", parser.AnnotatedEntry{Field: parser.Field{DataType: &parser.DataType{}}}, ""},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			g := new(Generator)
+			received := codeToString(g.unmarshallSliceArray("TestType", test.ae))
+
+			if test.expect != received {
+				t.Errorf("expected\n%s\nreceived\n%s", test.expect, received)
+			}
+		})
+
+	}
+}
+
+func TestGenerator_unmarshallMap(t *testing.T) {
+	g := new(Generator)
+
+	expect := `func (sf *TestType) unmarshallSomeStringSlice(r io.Reader) (err error) {
+	f := mint.NewMapCollection(map[mint.MarshallerUnmarshallerValuer]mint.MarshallerUnmarshallerValuer{})
+	f.ReadSize(r)
+	for i := 0; i < f.Len(); i++ {
+		f.V[mint.NewStringScalar("")] = mint.NewInt64Scalar(int64(0))
+	}
+	err = f.Unmarshall(r)
+	if err != nil {
+		return
+	}
+	sf.SomeStringSlice = make(map[string]int64)
+	for k, v := range f.Value().(map[mint.MarshallerUnmarshallerValuer]mint.MarshallerUnmarshallerValuer) {
+		sf.SomeStringSlice[k.Value().(string)] = v.Value().(int64)
+	}
+	return
+}`
+	received := codeToString(g.unmarshallMap("TestType", mapEntry))
+
+	if expect != received {
+		t.Errorf("expected\n%s\nreceived\n%s", expect, received)
+	}
+
+}
+
+func TestGenerator_unmarshallScalar(t *testing.T) {
+	g := new(Generator)
+
+	expect := `func (sf *TestType) unmarshallATypeOfSomeType(r io.Reader) (err error) {
+	f := mint.NewUuidScalar(v5.UUID{})
+	err = f.Unmarshall(r)
+	if err != nil {
+		return
+	}
+	sf.ATypeOfSomeType = f.Value().(v5.UUID)
+	return
+}`
+	received := codeToString(g.unmarshallScalar("TestType", scalarEntry))
+
+	if expect != received {
+		t.Errorf("expected\n%s\nreceived\n%s", expect, received)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,13 @@ go 1.20
 require (
 	github.com/alecthomas/participle/v2 v2.0.0
 	github.com/alecthomas/repr v0.2.0
+	github.com/dave/jennifer v1.6.1
 	github.com/gofrs/uuid/v5 v5.0.0
+	github.com/iancoleman/strcase v0.2.0
 	github.com/sergi/go-diff v1.3.1
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.16.0
+	golang.org/x/mod v0.10.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/dave/jennifer v1.6.1 h1:T4T/67t6RAA5AIV6+NP8Uk/BIsXgDoqEowgycdQQLuk=
+github.com/dave/jennifer v1.6.1/go.mod h1:nXbxhEmQfOZhWml3D1cDK5M1FLnMSozpbFN/m3RmGZc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -129,6 +131,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -233,6 +237,8 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.10.0 h1:lFO9qtOdlre5W1jxS3r/4szv2/6iXxScdzjoBMXNhYk=
+golang.org/x/mod v0.10.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/parser/collisions.go
+++ b/parser/collisions.go
@@ -58,7 +58,7 @@ func (c collisionsErr) Error() string {
 
 // namedSlice coerces a slice of types and enums into a slice of
 // named types to aid the ast solver
-func namedSlice(t []annotatedType, e []Enum) (out []named) {
+func namedSlice(t []AnnotatedType, e []Enum) (out []named) {
 	out = make([]named, len(t)+len(e))
 	idx := 0
 

--- a/parser/message.go
+++ b/parser/message.go
@@ -8,14 +8,14 @@ import (
 )
 
 type AST struct {
-	Types []annotatedType
+	Types []AnnotatedType
 	Enums []Enum
 }
 
 func toAST(d Document) (ad *AST, err error) {
 	ad = new(AST)
 	ad.Enums = make([]Enum, 0)
-	ad.Types = make([]annotatedType, 0)
+	ad.Types = make([]AnnotatedType, 0)
 
 	for _, e := range d.Entries {
 		if e.Enum != nil {
@@ -35,29 +35,29 @@ func toAST(d Document) (ad *AST, err error) {
 	return
 }
 
-type annotatedType struct {
+type AnnotatedType struct {
 	Pos     lexer.Position
 	Name    string
-	Entries []annotatedEntry
+	Entries []AnnotatedEntry
 }
 
-func (at annotatedType) name() string {
+func (at AnnotatedType) name() string {
 	return at.Name
 }
 
-func (at annotatedType) pos() lexer.Position {
+func (at AnnotatedType) pos() lexer.Position {
 	return at.Pos
 }
 
-type annotatedEntry struct {
+type AnnotatedEntry struct {
 	Field
 
 	DocString       string
-	Validations     []validation
-	Transformations []transformation
+	Validations     []Validation
+	Transformations []Transformation
 }
 
-func (ae *annotatedEntry) AppendDocString(s string) {
+func (ae *AnnotatedEntry) AppendDocString(s string) {
 	if len(ae.DocString) == 0 {
 		ae.DocString = s
 
@@ -66,17 +66,17 @@ func (ae *annotatedEntry) AppendDocString(s string) {
 	ae.DocString = ae.DocString + " " + s
 }
 
-func (ae *annotatedEntry) AppendValidation(v validation) {
+func (ae *AnnotatedEntry) AppendValidation(v Validation) {
 	if ae.Validations == nil {
-		ae.Validations = make([]validation, 0)
+		ae.Validations = make([]Validation, 0)
 	}
 
 	ae.Validations = append(ae.Validations, v)
 }
 
-func (ae *annotatedEntry) AppendTransformation(v transformation) {
+func (ae *AnnotatedEntry) AppendTransformation(v Transformation) {
 	if ae.Transformations == nil {
-		ae.Transformations = make([]transformation, 0)
+		ae.Transformations = make([]Transformation, 0)
 	}
 
 	ae.Transformations = append(ae.Transformations, v)
@@ -86,7 +86,7 @@ func (ae *annotatedEntry) AppendTransformation(v transformation) {
 //
 //  1. The specified type starts with a lower case and exists in our base scalars map; or
 //  2. It starts with an upper case and exists as a Type or Enum in our AST
-func (ae *annotatedEntry) IsValidType(names map[string][]lexer.Position) error {
+func (ae *AnnotatedEntry) IsValidType(names map[string][]lexer.Position) error {
 	var (
 		pos = ae.DataType.Pos
 
@@ -123,12 +123,12 @@ func (ae *annotatedEntry) IsValidType(names map[string][]lexer.Position) error {
 	return nil
 }
 
-type validation struct {
+type Validation struct {
 	IsCustom bool
 	Function string
 }
 
-type transformation struct {
+type Transformation struct {
 	IsCustom bool
 	Function string
 }
@@ -144,7 +144,7 @@ func (e incorrectTypeErr) Error() string {
 
 func scalarOrNames(s string, names map[string][]lexer.Position) bool {
 	if unicode.IsLower(rune(s[0])) {
-		_, ok := scalars[s]
+		_, ok := Scalars[s]
 		return ok
 	}
 

--- a/parser/message_test.go
+++ b/parser/message_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestAnnotatedEntry_IsValidType(t *testing.T) {
-	ae := &annotatedEntry{
+	ae := &AnnotatedEntry{
 		Field: Field{
 			DataType: &DataType{},
 		},

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -95,8 +95,8 @@ func TestParseDir(t *testing.T) {
 var (
 	emptyAST = new(AST)
 	fullAST  = &AST{
-		Types: []annotatedType{
-			annotatedType{
+		Types: []AnnotatedType{
+			AnnotatedType{
 				Pos: lexer.Position{
 					Filename: "valid input works",
 					Offset:   1,
@@ -104,8 +104,8 @@ var (
 					Column:   1,
 				},
 				Name: "Foo",
-				Entries: []annotatedEntry{
-					annotatedEntry{
+				Entries: []AnnotatedEntry{
+					AnnotatedEntry{
 						Field: Field{
 							Pos: lexer.Position{
 								Filename: "valid input works",
@@ -134,12 +134,12 @@ var (
 							Tag:  0,
 						},
 						DocString: "Hello, world! This is a multiline doc string :)",
-						Validations: []validation{
+						Validations: []Validation{
 							{
 								Function: "not_empty",
 							},
 						},
-						Transformations: []transformation{
+						Transformations: []Transformation{
 							{
 								Function: "to_lowercase",
 							},

--- a/parser/solver.go
+++ b/parser/solver.go
@@ -77,28 +77,28 @@ func merge(in []*AST) (out *AST, err error) {
 //
 // Groupings occur by parsing each entry until we hit a field definition, and then
 // merging those entries into a single definition.
-func toAnnotatedType(m Type) (a annotatedType, err error) {
+func toAnnotatedType(m Type) (a AnnotatedType, err error) {
 	a.Pos = m.Pos
 	a.Name = m.Name
-	a.Entries = make([]annotatedEntry, 0)
+	a.Entries = make([]AnnotatedEntry, 0)
 
 	names := make(map[string][]lexer.Position)
 	tags := make(map[string][]lexer.Position)
 	tagValues := make([]int, 0)
 
-	ae := annotatedEntry{}
+	ae := AnnotatedEntry{}
 	for _, e := range m.Entries {
 		if e.Annotation != nil {
 			switch e.Annotation.Type {
 			case "doc":
 				ae.AppendDocString(e.Annotation.Value)
 			case "validate":
-				ae.AppendValidation(validation{
+				ae.AppendValidation(Validation{
 					IsCustom: e.Annotation.Provider == "custom",
 					Function: e.Annotation.Func,
 				})
 			case "transform":
-				ae.AppendTransformation(transformation{
+				ae.AppendTransformation(Transformation{
 					IsCustom: e.Annotation.Provider == "custom",
 					Function: e.Annotation.Func,
 				})
@@ -126,7 +126,7 @@ func toAnnotatedType(m Type) (a annotatedType, err error) {
 
 		ae.Field = *e.Field
 		a.Entries = append(a.Entries, ae)
-		ae = annotatedEntry{}
+		ae = AnnotatedEntry{}
 	}
 
 	// Ensure names are unique

--- a/parser/types.go
+++ b/parser/types.go
@@ -1,7 +1,7 @@
 package parser
 
 var (
-	scalars = map[string]bool{
+	Scalars = map[string]bool{
 		"string":   true,
 		"datetime": true,
 		"uuid":     true,

--- a/testdata/valid-documents/location.mint
+++ b/testdata/valid-documents/location.mint
@@ -18,4 +18,12 @@ type Location {
     +mint:doc:"Tags contain an arbitrary list of tags for"
     +mint:doc:"labelling this location in some way"
     []string Tags = 3;
+
+    +mint:doc:"Labels contains a map key/values representing"
+    +mint:doc:"this location in some way"
+    map<string,string> Labels = 4;
+
+    +mint:doc:"ID is a UUID representing this location and is"
+    +mint:doc:"ever unchanging (whereas the Location name may)"
+    uuid ID = 5;
 }

--- a/testdata/valid-documents/weather-forecast.mint
+++ b/testdata/valid-documents/weather-forecast.mint
@@ -18,4 +18,12 @@ type WeatherForecast {
     +mint:doc:"oktas"
     +custom:validate:valid_okta
     int32 CloudCoverage = 2;
+
+    +mint:doc:"Date this forecast is for"
+    +mint:transform:date_in_utc
+    datetime ForecastedFor = 4;
+
+    +mint:doc:"WeatherKeys is a tuple that holds some arbitrary data that means..."
+    +mint:doc:"something"
+    [5]int16 WeatherKeys = 5;
 }


### PR DESCRIPTION
Provide a method for generating valid, compilable, go code from mint documents.

This can be accessed via the mint command as per:

```bash
Usage:
  mint generate ./directory/of/mint-documents [flags]

Flags:
  -c, --clobber          Clobber any pre-generated validators and/or transforms (note: this replaces all custom code back to placeholders)
  -d, --dest string      Directory to generate code into (default "types/")
  -f, --functions        Create skeleton functions for any custom validators and/or transforms found in documents
  -h, --help             help for generate
  -m, --mkdir            Create dest directory if not exist (note: if the destination directory exists then nothing happens) (default true)
  -p, --package string   Package to generate for (default "types")
```