### PR TITLE
Ensure collections of complex types marshall with no initialiser

### DIFF
--- a/generator/marshallers.go
+++ b/generator/marshallers.go
@@ -26,7 +26,7 @@ func (g Generator) marshallSliceArray(t string, e parser.AnnotatedEntry) jen.Cod
 	}
 
 	fn := marshallerFuncName(e.Name)
-	innerInitialiser, _, _ := scalarToMintJen(dt)
+	innerInitialiser := marshallerInitialiser(dt)
 
 	return jen.Func().Params(jen.Id("sf").Id(t)).Id(fn).Params(jen.Id("w").Qual("io", "Writer")).Params(jen.Id("err").Id("error")).
 		Block(
@@ -42,8 +42,8 @@ func (g Generator) marshallSliceArray(t string, e parser.AnnotatedEntry) jen.Cod
 func (g Generator) marshallMap(t string, e parser.AnnotatedEntry) jen.Code {
 	fn := marshallerFuncName(e.Name)
 
-	keyInitialiser, _, _ := scalarToMintJen(e.DataType.Map.Key)
-	valueInitialiser, _, _ := scalarToMintJen(e.DataType.Map.Value)
+	keyInitialiser := marshallerInitialiser(e.DataType.Map.Key)
+	valueInitialiser := marshallerInitialiser(e.DataType.Map.Value)
 
 	return jen.Func().Params(jen.Id("sf").Id(t)).Id(fn).Params(jen.Id("w").Qual("io", "Writer")).Params(jen.Id("err").Id("error")).
 		Block(
@@ -54,4 +54,14 @@ func (g Generator) marshallMap(t string, e parser.AnnotatedEntry) jen.Code {
 			jen.Return(jen.Qual(mintPath, "NewMapCollection").Call(jen.Id("f")).Dot("Marshall").Call(jen.Id("w"))),
 		)
 
+}
+
+func marshallerInitialiser(dt string) jen.Code {
+	if _, ok := parser.Scalars[dt]; ok {
+		i, _, _ := scalarToMintJen(dt)
+
+		return i
+	}
+
+	return jen.Op("&")
 }

--- a/generator/types_test.go
+++ b/generator/types_test.go
@@ -91,6 +91,53 @@ var (
 		},
 	}
 
+	userDefinedSliceEntry = parser.AnnotatedEntry{
+		Field: parser.Field{
+			Name: "Thingy",
+			DataType: &parser.DataType{
+				Slice: &parser.SliceType{
+					Type: "BlahType",
+				},
+			},
+		},
+	}
+
+	builtinToComplexMap = parser.AnnotatedEntry{
+		Field: parser.Field{
+			Name: "Thingy",
+			DataType: &parser.DataType{
+				Map: &parser.MapType{
+					Key:   "string",
+					Value: "BlahType",
+				},
+			},
+		},
+	}
+
+	complexToBuiltinMap = parser.AnnotatedEntry{
+		Field: parser.Field{
+			Name: "Thingy",
+			DataType: &parser.DataType{
+				Map: &parser.MapType{
+					Key:   "BlahType",
+					Value: "bool",
+				},
+			},
+		},
+	}
+
+	complexToComplexMap = parser.AnnotatedEntry{
+		Field: parser.Field{
+			Name: "Thingy",
+			DataType: &parser.DataType{
+				Map: &parser.MapType{
+					Key:   "BlahType",
+					Value: "BlahType",
+				},
+			},
+		},
+	}
+
 	simpleType = parser.AnnotatedType{
 		Name: "SomeTestType",
 		Entries: []parser.AnnotatedEntry{


### PR DESCRIPTION
The initialiser we generate is largely only useful for nil values; specifically when we're building unmarshallers.

It just so happens that it also works for marshalling builtin/ native types.

For complex types, the method of passing a value to `new()` wont work; that isn't what `new()` does.

Instead, though, because our `mint.MarshallerUnmarshallerValuer` expects a pointer receiver anyway, we can sub-out intialiser functions for an ampersand.