### PR TITLE
Set empty collections to nil value

### DIFF
--- a/generator/types_test.go
+++ b/generator/types_test.go
@@ -163,6 +163,10 @@ func (sf *SomeTestType) unmarshallSomeStringSlice(r io.Reader) (err error) {
 	if err != nil {
 		return
 	}
+	if f.Len() == 0 {
+		sf.SomeStringSlice = nil
+		return
+	}
 	f.V = make([]mint.MarshallerUnmarshallerValuer, f.Len())
 	for i := range f.V {
 		f.V[i] = mint.NewStringScalar("")
@@ -196,6 +200,10 @@ func (sf *SomeTestType) unmarshallSomeStringSlice(r io.Reader) (err error) {
 	f := mint.NewMapCollection(map[mint.MarshallerUnmarshallerValuer]mint.MarshallerUnmarshallerValuer{})
 	err = f.ReadSize(r)
 	if err != nil {
+		return
+	}
+	if f.Len() == 0 {
+		sf.SomeStringSlice = nil
 		return
 	}
 	for i := 0; i < f.Len(); i++ {

--- a/generator/unmarshallers.go
+++ b/generator/unmarshallers.go
@@ -69,7 +69,10 @@ func (g Generator) unmarshallMap(t string, e parser.AnnotatedEntry) jen.Code {
 			jen.If(jen.Id("err").Op("!=").Id("nil")).Block(
 				jen.Return(),
 			),
-
+			jen.If(jen.Id("f").Dot("Len").Call().Op("==").Lit(0)).Block(
+				jen.Id("sf").Dot(e.Name).Op("=").Id("nil"),
+				jen.Return(),
+			),
 			jen.For(jen.Id("i").Op(":=").Lit(0), jen.Id("i").Op("<").Id("f").Dot("Len").Call(), jen.Id("i").Op("++")).Block(
 				jen.Id("f").Dot("V").Index(jen.Add(keyInitialiser).Call(keyNilValue)).Op("=").Add(valueInitialiser).Call(valueNilValue),
 			),
@@ -110,6 +113,10 @@ func unmarshallSlicePreludeGetLen(e parser.AnnotatedEntry) []jen.Code {
 		jen.Id("f").Op(":=").Id("mint").Dot("NewSliceCollection").Call(jen.Id("nil"), jen.Id("false")),
 		jen.Id("err").Op("=").Id("f").Dot("ReadSize").Call(jen.Id("r")),
 		jen.If(jen.Id("err").Op("!=").Id("nil")).Block(
+			jen.Return(),
+		),
+		jen.If(jen.Id("f").Dot("Len").Call().Op("==").Lit(0)).Block(
+			jen.Id("sf").Dot(e.Name).Op("=").Id("nil"),
 			jen.Return(),
 		),
 		jen.Id("f").Dot("V").Op("=").Id("make").Call(jen.Index().Qual(mintPath, "MarshallerUnmarshallerValuer"), jen.Id("f").Dot("Len").Call()),

--- a/generator/unmarshallers_test.go
+++ b/generator/unmarshallers_test.go
@@ -13,6 +13,10 @@ var (
 	if err != nil {
 		return
 	}
+	if f.Len() == 0 {
+		sf.SomeStringSlice = nil
+		return
+	}
 	f.V = make([]mint.MarshallerUnmarshallerValuer, f.Len())
 	for i := range f.V {
 		f.V[i] = mint.NewStringScalar("")
@@ -75,6 +79,10 @@ func TestGenerator_unmarshallMap(t *testing.T) {
 	f := mint.NewMapCollection(map[mint.MarshallerUnmarshallerValuer]mint.MarshallerUnmarshallerValuer{})
 	err = f.ReadSize(r)
 	if err != nil {
+		return
+	}
+	if f.Len() == 0 {
+		sf.SomeStringSlice = nil
 		return
 	}
 	for i := 0; i < f.Len(); i++ {


### PR DESCRIPTION
Given a type:

```golang
type Foo struct {
     Bar []string
}
```

When `Foo.Bar` is uninitialised/ `nil`, we Marshall with a Len of 0. When we then Unmarshall we initialise a `[]string` of length 0.

The problem here is that a `nil` slice and a slice of `len()` 0 are two different things. Thus, when we try:

```golang
in := new(Foo)
in.Marshall(buf)

out := new(Foo)
out.Unmarshall(buf)
```

our types don't match up.

By testing whether `f.Len() == 0` and setting `Foo.Bar` as the nil value, rather than anything else, we know our collection should be nil.

Of course, this wont work if the collection _should_ be of length 0.