### PR TITLE
Use default permissions for builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     tags:
       - '*'
 
-permissions: read-all
+#permissions: read-all
 
 jobs:
   test:


### PR DESCRIPTION
For some reason dependabot wont run tests. Like, at all.

Since this is the only uncommon thing my workflow uses, disable and test