### PR TITLE
Support enums

### DIFF
--- a/generator/enums.go
+++ b/generator/enums.go
@@ -1,0 +1,51 @@
+package generator
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/dave/jennifer/jen"
+	"github.com/vinyl-linux/mint/parser"
+)
+
+func (g *Generator) generateForEnum(t parser.Enum) (err error) {
+	ret := jen.NewFile(g.PackageName)
+
+	// Create type as a uint8
+	ret.Add(g.generateEnumDefinition(t))
+
+	// Create values
+	ret.Add(g.generateEnumValues(t))
+
+	// Create marshaller, unmarshaller, valuer
+	ret.Add(g.marshallEnum(t.Name))
+	ret.Add(g.unmarshallEnum(t))
+	ret.Add(g.generateValuer(t.Name))
+
+	return ret.Save(filepath.Join(g.Directory, strings.Join([]string{strings.ToLower(t.Name), "go"}, ".")))
+}
+
+func (g *Generator) generateEnumDefinition(t parser.Enum) jen.Code {
+	return jen.Null().Type().Id(t.Name).Id("byte")
+}
+
+func (g *Generator) generateEnumValues(t parser.Enum) jen.Code {
+	consts := make([]jen.Code, len(t.Values)+1)
+
+	consts[0] = jen.Id(enumValueString(t.Name, "Unknown")).Id(t.Name).Op("=").Id("iota")
+
+	for idx, ev := range t.Values {
+		consts[idx+1] = jen.Id(enumValue(t.Name, ev))
+	}
+
+	return jen.Null().Const().Defs(consts...)
+}
+
+func enumValue(en string, ee *parser.EnumEntry) string {
+	return enumValueString(en, ee.Value.Key)
+}
+
+func enumValueString(en, ee string) string {
+	return fmt.Sprintf("%s%s", en, ee)
+}

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -57,13 +57,15 @@ func TestGenerator_Generate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expect := "h1:4zaocS5qbH8uRHYYKVq6ohH4QevkDfTBqm6PhUgTbrI="
+	expect := "h1:MCTzrW/TITvfxtJO5tfLuhPU7Vdsf2hsLzhJoz/if/k="
 	received, err := dirhash.HashDir(dir, "", dirhash.DefaultHash)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if expect != received {
+		t.Log(dir)
+
 		t.Fatalf("expected %q, received %q", expect, received)
 	}
 }
@@ -249,7 +251,7 @@ func TestGenerator_generateValuer(t *testing.T) {
 	expect := `func (sf SomeTestType) Value() any {
 	return sf
 }`
-	received := codeToString(g.generateValuer(simpleType))
+	received := codeToString(g.generateValuer(simpleType.Name))
 
 	if expect != received {
 		t.Errorf("expected\n%s\nreceived\n%s", expect, received)

--- a/generator/marshallers.go
+++ b/generator/marshallers.go
@@ -56,6 +56,13 @@ func (g Generator) marshallMap(t string, e parser.AnnotatedEntry) jen.Code {
 
 }
 
+func (g Generator) marshallEnum(t string) jen.Code {
+	return jen.Func().Params(jen.Id("sf").Id(t)).Id("Marshall").Params(jen.Id("w").Qual("io", "Writer")).Params(jen.Id("err").Id("error")).
+		Block(
+			jen.Return(jen.Qual(mintPath, "NewByteScalar").Call(jen.Id("byte").Call(jen.Id("sf"))).Dot("Marshall").Call(jen.Id("w"))),
+		)
+}
+
 func marshallerInitialiser(dt string) jen.Code {
 	if _, ok := parser.Scalars[dt]; ok {
 		i, _, _ := scalarToMintJen(dt)

--- a/generator/types.go
+++ b/generator/types.go
@@ -1,0 +1,59 @@
+package generator
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/dave/jennifer/jen"
+	"github.com/vinyl-linux/mint/parser"
+)
+
+func (g *Generator) generateForType(t parser.AnnotatedType) (err error) {
+	g.customFunctions = make([]jen.Code, 0)
+
+	ret := jen.NewFile(g.PackageName)
+
+	ret.Add(g.generateTypeDefinition(t))
+	ret.Add(g.generateValidations(t))
+	ret.Add(g.generateTransformations(t))
+	ret.Add(g.generateValuer(t.Name))
+
+	// We need to manually run these loops, rather than exploding
+	// the output of generateUnmarshaller (etc.) as per:
+	//
+	//  ret.Add(g.generateUnmarshaller(t)...)
+	//
+	// because doing so creates invalid code for whatever
+	// reason
+	for _, u := range g.generateUnmarshaller(t) {
+		ret.Add(u)
+	}
+
+	for _, u := range g.generateMarshaller(t) {
+		ret.Add(u)
+	}
+
+	err = g.writeSkeletons(t.Name)
+	if err != nil {
+		return
+	}
+
+	return ret.Save(filepath.Join(g.Directory, strings.Join([]string{strings.ToLower(t.Name), "go"}, ".")))
+}
+
+// generateTypeDefinition creates the top level struct from names, types, and
+// doc strings
+func (g *Generator) generateTypeDefinition(at parser.AnnotatedType) (c jen.Code) {
+	fields := make([]jen.Code, 0)
+	for _, f := range at.Entries {
+		if len(f.DocString) > 0 {
+			fields = append(fields, jen.Null().Comment(f.DocString))
+		}
+
+		fields = append(fields, jen.Null().Id(f.Name).Add(toJenType(f.Field)))
+	}
+
+	return jen.Null().Type().Id(at.Name).Struct(
+		fields...,
+	)
+}

--- a/generator/unmarshallers.go
+++ b/generator/unmarshallers.go
@@ -108,6 +108,21 @@ func (g Generator) unmarshallScalar(t string, e parser.AnnotatedEntry) jen.Code 
 		)
 }
 
+func (g Generator) unmarshallEnum(e parser.Enum) jen.Code {
+	initialiser, nilValue, _ := scalarToMintJen("uint8")
+
+	return jen.Func().Params(jen.Id("sf").Op("*").Id(e.Name)).Id("Unmarshall").Params(jen.Id("r").Qual("io", "Reader")).Params(jen.Id("err").Id("error")).
+		Block(
+			jen.Id("f").Op(":=").Add(initialiser).Call(nilValue),
+			jen.Id("err").Op("=").Id("f").Dot("Unmarshall").Call(jen.Id("r")),
+			jen.If(jen.Id("err").Op("!=").Id("nil")).Block(
+				jen.Return(),
+			),
+			jen.Id("*sf").Op("=").Id("f").Dot("Value").Call().Assert(jen.Id(e.Name)),
+			jen.Return(),
+		)
+}
+
 func unmarshallSlicePreludeGetLen(e parser.AnnotatedEntry) []jen.Code {
 	return []jen.Code{
 		jen.Id("f").Op(":=").Id("mint").Dot("NewSliceCollection").Call(jen.Id("nil"), jen.Id("false")),

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -53,8 +53,7 @@ type EnumEntry struct {
 type EnumValue struct {
 	Pos lexer.Position
 
-	Key   string `@Ident`
-	Value int    `"=" @( [ "-" ] Int )`
+	Key string `@Ident`
 }
 
 type Type struct {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -295,44 +295,41 @@ var (
 								Line:     19,
 								Column:   3,
 							},
-							Key:   "A",
-							Value: 1,
+							Key: "A",
 						},
 					},
 					{
 						Pos: lexer.Position{
 							Filename: "valid input works",
-							Offset:   366,
+							Offset:   361,
 							Line:     20,
 							Column:   3,
 						},
 						Value: &EnumValue{
 							Pos: lexer.Position{
 								Filename: "valid input works",
-								Offset:   366,
+								Offset:   361,
 								Line:     20,
 								Column:   3,
 							},
-							Key:   "B",
-							Value: 2,
+							Key: "B",
 						},
 					},
 					{
 						Pos: lexer.Position{
 							Filename: "valid input works",
-							Offset:   375,
+							Offset:   365,
 							Line:     21,
 							Column:   3,
 						},
 						Value: &EnumValue{
 							Pos: lexer.Position{
 								Filename: "valid input works",
-								Offset:   375,
+								Offset:   365,
 								Line:     21,
 								Column:   3,
 							},
-							Key:   "C",
-							Value: 3,
+							Key: "C",
 						},
 					},
 				},
@@ -381,9 +378,9 @@ type Foo {
 }
 
 enum Bar {
-  A = 1;
-  B = 2;
-  C = 3;
+  A
+  B
+  C
 }
 `
 

--- a/testdata/valid-documents/location.mint
+++ b/testdata/valid-documents/location.mint
@@ -26,4 +26,14 @@ type Location {
     +mint:doc:"ID is a UUID representing this location and is"
     +mint:doc:"ever unchanging (whereas the Location name may)"
     uuid ID = 5;
+
+    +mint:doc:"Type of location this is, such as home or whatever"
+    LocationType Type = 6;
+}
+
+enum LocationType {
+     Home
+     Work
+     School
+     Other
 }


### PR DESCRIPTION
This PR:

1. Simplifies enums; and
2. Generates marshallers and unmarshallers for them

In mint an enum is a byte wide, so only supports 256 values. Furthermore, the 0 value of an enum is reserved as the 'unknown/ unset' value. Thus, there's no need to specify a specific value for this. This also means that functionally there are only 255 user specifiable enum values.

An enum is created in the order in which it's defined. In the go world, the mint enum:

```
enum LocationType {
     Home
     Work
     School
     Other
}
```

generates the go code/ values:

```golang
type LocationType byte

const (
        LocationTypeUnknown LocationType = iota
        LocationTypeHome
        LocationTypeWork
        LocationTypeSchool
        LocationTypeOther
)
```