### PR TITLE
Provide a uint16 type for 2-byte wide positive numbers

### DIFF
--- a/docs/scheme.md
+++ b/docs/scheme.md
@@ -25,6 +25,7 @@ Mint supports the following fixed length types. These types are read from a stre
 | datetime | int64 of nanoseconds since the [epoch](https://en.wikipedia.org/wiki/Unix_time) without TZ               | 8 Bytes      | Little Endian |
 | uuid     | fixed length array of 16 bytes containing the components of a uuid                                       | 16 Bytes     | Little Endian |
 | int16    | 16 bit integer, useful where numbers are known to be low                                                 | 2 Bytes      | Little Endian |
+| uint16   | Unsigned 16 bit integer                                                                                  | 2 Bytes      | Little Endian |
 | int32    | 32 bit integer                                                                                           | 4 Bytes      | Little Endian |
 | uint32   | Unsigned 32 bit integer; useful for larger positive numbers where keeping binary size down is important  | 4 Bytes      | Little Endian |
 | int64    | 64 bit integer; the recommended numeric type for modern architectures                                    | 8 Bytes      | Little Endian |
@@ -33,6 +34,9 @@ Mint supports the following fixed length types. These types are read from a stre
 | byte     | Single byte of information, useful for encoded data when coupled with a Slice type                       | 1 Byte       | Little Endian |
 | bool     | Boolean value; either true or false                                                                      | 1 Byte       | Little Endian |
 
+There are also the following type aliases:
+
+1. `int8` -> `byte`
 
 ### Unbounded types
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -346,6 +346,9 @@ func scalarToMintJen(ts string) (c, nilValue, castType jen.Code) {
 
 	case "byte", "uint8":
 		return jen.Qual(mintPath, "NewByteScalar"), jen.Id("byte").Call(jen.Lit('\x00')), jen.Id(ts)
+
+	case "uint16":
+		return jen.Qual(mintPath, "NewUint16Scalar"), jen.Id("uint16").Call(jen.Lit(0)), jen.Id(ts)
 	}
 
 	return jen.Id("new"), jen.Id(ts), jen.Id(ts)

--- a/scalar_types.go
+++ b/scalar_types.go
@@ -318,3 +318,25 @@ func (s *BoolScalar) Unmarshall(r io.Reader) (err error) {
 func (s BoolScalar) Value() any {
 	return s.v
 }
+
+type Uint16Scalar struct {
+	v uint16
+}
+
+func NewUint16Scalar(i uint16) *Uint16Scalar {
+	return &Uint16Scalar{
+		v: i,
+	}
+}
+
+func (s *Uint16Scalar) Marshall(w io.Writer) error {
+	return binary.Write(w, binary.LittleEndian, s.v)
+}
+
+func (s *Uint16Scalar) Unmarshall(r io.Reader) (err error) {
+	return binary.Read(r, binary.LittleEndian, &s.v)
+}
+
+func (s Uint16Scalar) Value() any {
+	return s.v
+}

--- a/scalar_types_test.go
+++ b/scalar_types_test.go
@@ -625,6 +625,62 @@ func TestBoolScalar(t *testing.T) {
 	}
 }
 
+func TestUint16Scalar(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		i              uint16
+		expectWriteErr bool
+		expectReadErr  bool
+	}{
+		{"Zero value should remain as such", uint16(0), false, false},
+		{"Malformed zero value should remain as such", uint16(0000000), false, false},
+		{"Large number with underscore delimeter should remain as such", uint16(10_000), false, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			v := NewUint16Scalar(test.i)
+			if v == nil {
+				t.Fatalf("expected instance of Uint16Scalar, received null")
+			}
+
+			b := new(bytes.Buffer)
+			t.Run("Marshall", func(t *testing.T) {
+				err := v.Marshall(b)
+				if err == nil && test.expectWriteErr {
+					t.Errorf("expected error, received none")
+				} else if err != nil && !test.expectWriteErr {
+					t.Errorf("unexpected error %#v", err)
+				}
+
+				if b.Len() == 0 {
+					t.Errorf("no bytes were written")
+				}
+			})
+
+			t.Run("Unmarshall", func(t *testing.T) {
+				v = new(Uint16Scalar)
+
+				err := v.Unmarshall(b)
+				if err == nil && test.expectReadErr {
+					t.Errorf("expected error, received none")
+				} else if err != nil && !test.expectReadErr {
+					t.Errorf("unexpected error %#v", err)
+				}
+
+				if b.Len() > 0 {
+					t.Errorf("bytes left over: %#v", b.Bytes())
+				}
+			})
+
+			t.Run("Value", func(t *testing.T) {
+				received := v.Value().(uint16)
+				if test.i != received {
+					t.Errorf("expected %v, received %v", test.i, received)
+				}
+			})
+		})
+	}
+}
+
 func makeLongString() string {
 	sb := strings.Builder{}
 	for i := 0; i < 100_000; i++ {


### PR DESCRIPTION
In gordon we need a type to signify the number of packets a document has been split into. We could use a `u32`, but the number will never be negative and even though 2 bytes is bugger all, we might as well create a new type now and save space.